### PR TITLE
Fixed context-menu disappearing after FireFox restart.

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Kenteken, pls",
     "description": "Gemakkelijk testen met kentekens, kies een categorie en kenteken, pls zal een willekeurig (actief) kenteken invoegen in het veld.",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self';",
     "permissions": [
         "contextMenus",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kentekenpls-ext",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Gemakkelijk testen met kentekens, kies een categorie en kenteken, pls zal een willekeurig (actief) kenteken invoegen in het veld.",
   "main": "src/app/index.tsx",
   "repository": {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -56,8 +56,4 @@ chrome.contextMenus.onClicked.addListener(
     }
 );
 
-chrome.runtime.onInstalled.addListener(
-    () => {
-        createMenu();
-    }
-);
+createMenu();


### PR DESCRIPTION
Context-menu is now created on background script load and not on `onInstalled`-event (which in FireFox only runs after actual installation/upgrade of the extension)

Closes #22 